### PR TITLE
Fixing off by one

### DIFF
--- a/src/main/kotlin/com/spectralogic/rioBench/commands/Benchmark.kt
+++ b/src/main/kotlin/com/spectralogic/rioBench/commands/Benchmark.kt
@@ -60,7 +60,7 @@ class Benchmark : CliktCommand(help = "Run the benchmark suite", name = "benchma
     }
 
     fun CoroutineScope.jobNumber(): ReceiveChannel<Long> = produce {
-        LongRange(0, jobs).forEach {
+        LongRange(1, jobs).forEach {
             send(it)
         }
     }
@@ -71,7 +71,7 @@ class Benchmark : CliktCommand(help = "Run the benchmark suite", name = "benchma
         for (job in channel) {
             send(
                 FilesToArchive(
-                    LongRange(0, number)
+                    LongRange(1, number)
                         .map { file ->
                             makeFileToArchive(job, file, timestamp, itemSize)
                         }.toList()


### PR DESCRIPTION
Ranges in kotlin are inclusive, so 0..x has x+1 elements.